### PR TITLE
Give the SVG a background color so it works on a dark background

### DIFF
--- a/violin.svg
+++ b/violin.svg
@@ -1,4 +1,5 @@
 <svg width="960" height="366" viewBox="0 0 960 366" xmlns="http://www.w3.org/2000/svg">
+<rect width="960" height="366" fill="#fff"/>
 <text x="480" y="5" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="16.129032258064516" opacity="1" fill="#000000">
 Compression: Violin plot
 </text>


### PR DESCRIPTION
The SVG graph had a transparent background and black text, which made it
unreadable against a dark background (such as GitHub's dark mode). Give
it an opaque white background, so it works anywhere.