### PR TITLE
Expose FooterValues sum and amount

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,9 +396,9 @@ pub trait FormatSpec: Clone + Copy + Debug + Send + Sync + 'static {
 #[derive(Debug, Copy, Clone)]
 pub struct FooterValues {
     /// The check sum
-    sum: u32,
+    pub sum: u32,
     /// The number of bytes that went into the sum
-    amount: u32,
+    pub amount: u32,
 }
 
 pub trait BlockFormatSpec: FormatSpec {


### PR DESCRIPTION
This is needed so we know how many bytes for the output buffer is needed.  FooterValues is returned by `Bgzf::bgzf.get_footer_values` (in BlockFormatSpec).