### PR TITLE
Make the bgzf module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ use crate::syncz::{SyncZ, SyncZBuilder};
 pub use crate::bgzf::{BgzfSyncReader, BgzfSyncWriter};
 pub use crate::mgzip::{MgzipSyncReader, MgzipSyncWriter};
 
-mod bgzf;
+pub mod bgzf;
 pub mod check;
 #[cfg(feature = "deflate")]
 pub mod deflate;


### PR DESCRIPTION
So we can use `gzp::bgzf::decompress` directly