### PR TITLE
Bump core_affinity to v0.7.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "core_affinity"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2ebd14a61ca9d5289105b02fe9075ca19eeb2c38fdb64fac76f883048113ee"
+checksum = "479fdfb5e75b80b678a34a8231b4415481b06b706e486bf5b3ba72378710caaf"
 dependencies = [
  "libc",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ flate2 = { version = "~1", default-features = false, optional = true }
 libdeflater = { version = "0.11.0", optional = true }
 libz-sys = { version = "1.1.3", default-features = false, optional = true }
 snap = { version = "~1", optional = true }
-core_affinity = "0.7.5"
+core_affinity = "0.7.6"
 
 [dev-dependencies]
 proptest = "1.0.0"


### PR DESCRIPTION
Address a freebsd issue:
https://github.com/Elzair/core_affinity_rs/pull/15

for sccache
https://github.com/mozilla/sccache/pull/1184