### PR TITLE
Support writers without static lifetimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          override: true
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
@@ -41,7 +40,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt, clippy
 
       - name: Cache dependencies
@@ -74,7 +72,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          override: true
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- feat: Add `ParCompress::from_borrowed_writer` to support compression when the inner writer borrows data for the lifetime of a specific scope
+
 # v1.0.1
 
 - chore: update core-affinity to 0.8.2 for NetBSD support

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,7 +15,7 @@ fn compress_with_gzip(num_threads: usize, buffer_size: usize, compression_level:
     let dir = tempdir().unwrap();
     let output_file = File::create(dir.path().join("shakespeare_gzip.txt.gz")).unwrap();
 
-    let mut writer: Box<dyn ZWriter> = if num_threads > 0 {
+    let mut writer: Box<dyn ZWriter<_>> = if num_threads > 0 {
         Box::new(
             ParCompressBuilder::<Gzip>::new()
                 .num_threads(num_threads)
@@ -50,7 +50,7 @@ fn compress_with_gzip(num_threads: usize, buffer_size: usize, compression_level:
 fn compress_with_snap(num_threads: usize, buffer_size: usize) {
     let dir = tempdir().unwrap();
     let output_file = File::create(dir.path().join("shakespeare_gzip.txt.gz")).unwrap();
-    let mut writer: Box<dyn ZWriter> = if num_threads > 0 {
+    let mut writer: Box<dyn ZWriter<_>> = if num_threads > 0 {
         Box::new(
             ParCompressBuilder::<Snap>::new()
                 .num_threads(num_threads)

--- a/examples/test1.rs
+++ b/examples/test1.rs
@@ -8,7 +8,7 @@ mod example {
     pub fn main() {
         let file = env::args().skip(1).next().unwrap();
         let writer = File::create(file).unwrap();
-        let mut parz: ParCompress<Gzip> = ParCompressBuilder::new().from_writer(writer);
+        let mut parz: ParCompress<Gzip, _> = ParCompressBuilder::new().from_writer(writer);
         parz.write_all(b"This is a first test line\n").unwrap();
         parz.write_all(b"This is a second test line\n").unwrap();
         parz.finish().unwrap();

--- a/examples/test2.rs
+++ b/examples/test2.rs
@@ -12,7 +12,7 @@ mod example {
         let chunksize = 64 * (1 << 10) * 2;
 
         let stdout = std::io::stdout();
-        let mut writer: ParCompress<Gzip> = ParCompressBuilder::new()
+        let mut writer: ParCompress<Gzip, _> = ParCompressBuilder::new()
             .compression_level(Compression::new(6))
             .from_writer(stdout);
 

--- a/examples/test3.rs
+++ b/examples/test3.rs
@@ -1,0 +1,29 @@
+//! This example demonstrates how to use scoped threads with ParCompress.
+#[cfg(feature = "deflate")]
+mod example {
+    use gzp::deflate::Gzip;
+    use gzp::par::compress::ParCompressBuilder;
+    use gzp::ZWriter;
+    use std::io::Write;
+
+    pub fn main() {
+        let mut output = Vec::new();
+
+        std::thread::scope(|scope| {
+            let mut compressor =
+                ParCompressBuilder::<Gzip>::new().from_borrowed_writer(&mut output, scope);
+            compressor.write_all(b"Data to compress").unwrap();
+            compressor.finish().unwrap()
+        });
+        println!("Compressed size: {}", output.len());
+    }
+}
+
+#[cfg(not(feature = "deflate"))]
+mod example {
+    pub fn main() {}
+}
+
+fn main() {
+    example::main()
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.80.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.80.0"
+components = ["rustfmt", "clippy"]

--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -15,7 +15,7 @@
 //! use gzp::{deflate::Zlib, par::compress::{ParCompress, ParCompressBuilder}, ZWriter};
 //!
 //! let mut writer = vec![];
-//! let mut parz: ParCompress<Zlib> = ParCompressBuilder::new().from_writer(writer);
+//! let mut parz: ParCompress<Zlib,_> = ParCompressBuilder::new().from_writer(writer);
 //! parz.write_all(b"This is a first test line\n").unwrap();
 //! parz.write_all(b"This is a second test line\n").unwrap();
 //! parz.finish().unwrap();
@@ -153,10 +153,9 @@ where
     }
 }
 
-impl<W: Write> ZWriter for SyncZ<GzEncoder<W>> {
-    fn finish(&mut self) -> Result<(), GzpError> {
-        self.inner.take().unwrap().finish()?;
-        Ok(())
+impl<W: Write> ZWriter<W> for SyncZ<GzEncoder<W>> {
+    fn finish(&mut self) -> Result<W, GzpError> {
+        Ok(self.inner.take().unwrap().finish()?)
     }
 }
 
@@ -265,10 +264,9 @@ where
 }
 
 #[cfg(feature = "any_zlib")]
-impl<W: Write> ZWriter for SyncZ<ZlibEncoder<W>> {
-    fn finish(&mut self) -> Result<(), GzpError> {
-        self.inner.take().unwrap().finish()?;
-        Ok(())
+impl<W: Write> ZWriter<W> for SyncZ<ZlibEncoder<W>> {
+    fn finish(&mut self) -> Result<W, GzpError> {
+        Ok(self.inner.take().unwrap().finish()?)
     }
 }
 
@@ -344,10 +342,9 @@ where
     }
 }
 
-impl<W: Write> ZWriter for SyncZ<DeflateEncoder<W>> {
-    fn finish(&mut self) -> Result<(), GzpError> {
-        self.inner.take().unwrap().finish()?;
-        Ok(())
+impl<W: Write> ZWriter<W> for SyncZ<DeflateEncoder<W>> {
+    fn finish(&mut self) -> Result<W, GzpError> {
+        Ok(self.inner.take().unwrap().finish()?)
     }
 }
 
@@ -494,10 +491,9 @@ where
     }
 }
 
-impl<W: Write> ZWriter for SyncZ<MgzipSyncWriter<W>> {
-    fn finish(&mut self) -> Result<(), GzpError> {
-        self.inner.take().unwrap().flush()?;
-        Ok(())
+impl<W: Write> ZWriter<W> for SyncZ<MgzipSyncWriter<W>> {
+    fn finish(&mut self) -> Result<W, GzpError> {
+        Ok(self.inner.take().unwrap().finish()?)
     }
 }
 
@@ -650,10 +646,9 @@ where
     }
 }
 
-impl<W: Write> ZWriter for SyncZ<BgzfSyncWriter<W>> {
-    fn finish(&mut self) -> Result<(), GzpError> {
-        self.inner.take().unwrap().flush()?;
-        Ok(())
+impl<W: Write> ZWriter<W> for SyncZ<BgzfSyncWriter<W>> {
+    fn finish(&mut self) -> Result<W, GzpError> {
+        Ok(self.inner.take().unwrap().finish()?)
     }
 }
 
@@ -695,7 +690,7 @@ mod test {
         ";
 
         // Compress input to output
-        let mut par_gz: ParCompress<Mgzip> = ParCompressBuilder::new().from_writer(out_writer);
+        let mut par_gz: ParCompress<Mgzip, _> = ParCompressBuilder::new().from_writer(out_writer);
         par_gz.write_all(input).unwrap();
         par_gz.finish().unwrap();
 
@@ -728,7 +723,7 @@ mod test {
         ";
 
         // Compress input to output
-        let mut par_gz: ParCompress<Gzip> = ParCompressBuilder::new().from_writer(out_writer);
+        let mut par_gz: ParCompress<Gzip, _> = ParCompressBuilder::new().from_writer(out_writer);
         par_gz.write_all(input).unwrap();
         par_gz.finish().unwrap();
 
@@ -761,7 +756,7 @@ mod test {
         ";
 
         // Compress input to output
-        let mut par_gz: ParCompress<Gzip> = ParCompressBuilder::new().from_writer(out_writer);
+        let mut par_gz: ParCompress<Gzip, _> = ParCompressBuilder::new().from_writer(out_writer);
         par_gz.write_all(input).unwrap();
         drop(par_gz);
 
@@ -861,7 +856,7 @@ mod test {
         ";
 
         // Compress input to output
-        let mut par_gz: ParCompress<Zlib> = ParCompressBuilder::new().from_writer(out_writer);
+        let mut par_gz: ParCompress<Zlib, _> = ParCompressBuilder::new().from_writer(out_writer);
         par_gz.write_all(input).unwrap();
         par_gz.finish().unwrap();
 
@@ -938,7 +933,7 @@ mod test {
         ];
 
         // Compress input to output
-        let mut par_gz: ParCompress<Gzip> = ParCompressBuilder::new()
+        let mut par_gz: ParCompress<Gzip, _> = ParCompressBuilder::new()
             .buffer_size(DICT_SIZE)
             .unwrap()
             .from_writer(out_writer);
@@ -974,7 +969,7 @@ mod test {
         ";
 
         // Compress input to output
-        let mut par_gz: ParCompress<Mgzip> = ParCompressBuilder::new().from_writer(out_writer);
+        let mut par_gz: ParCompress<Mgzip, _> = ParCompressBuilder::new().from_writer(out_writer);
         par_gz.write_all(input).unwrap();
         par_gz.finish().unwrap();
 
@@ -1003,7 +998,7 @@ mod test {
         ";
 
         // Compress input to output
-        let mut par_gz: ParCompress<Bgzf> = ParCompressBuilder::new().from_writer(out_writer);
+        let mut par_gz: ParCompress<Bgzf, _> = ParCompressBuilder::new().from_writer(out_writer);
         par_gz.write_all(input).unwrap();
         par_gz.finish().unwrap();
 
@@ -1040,7 +1035,7 @@ mod test {
 
 
             // Compress input to output
-            let mut par_gz: Box<dyn ZWriter> = if num_threads > 0 {
+            let mut par_gz: Box<dyn ZWriter<_>> = if num_threads > 0 {
                 Box::new(ParCompressBuilder::<Gzip>::new()
                     .buffer_size(buf_size).unwrap()
                     .num_threads(num_threads).unwrap()
@@ -1086,7 +1081,7 @@ mod test {
 
 
             // Compress input to output
-            let mut par_gz: Box<dyn ZWriter> = if num_threads > 0 {
+            let mut par_gz: Box<dyn ZWriter<_>> = if num_threads > 0 {
                 Box::new(ParCompressBuilder::<Mgzip>::new()
                     .buffer_size(buf_size).unwrap()
                     .num_threads(num_threads).unwrap()
@@ -1183,7 +1178,7 @@ mod test {
             }
 
             // Compress input to output
-            let mut par_gz: Box<dyn ZWriter> = if num_threads > 0 {
+            let mut par_gz: Box<dyn ZWriter<_>> = if num_threads > 0 {
                 Box::new(ParCompressBuilder::<Bgzf>::new()
                     .buffer_size(buf_size).unwrap()
                     .num_threads(num_threads).unwrap()
@@ -1316,7 +1311,7 @@ mod test {
 
 
             // Compress input to output
-            let mut par_gz: Box<dyn ZWriter> = if num_threads > 0 {
+            let mut par_gz: Box<dyn ZWriter<_>> = if num_threads > 0 {
                 Box::new(ParCompressBuilder::<Zlib>::new()
                     .buffer_size(buf_size).unwrap()
                     .num_threads(num_threads).unwrap()

--- a/src/par/compress.rs
+++ b/src/par/compress.rs
@@ -9,7 +9,7 @@
 //! use gzp::{par::compress::{ParCompress, ParCompressBuilder}, deflate::Gzip, ZWriter};
 //!
 //! let mut writer = vec![];
-//! let mut parz: ParCompress<Gzip> = ParCompressBuilder::new().from_writer(writer);
+//! let mut parz: ParCompress<Gzip, _> = ParCompressBuilder::new().from_writer(writer);
 //! parz.write_all(b"This is a first test line\n").unwrap();
 //! parz.write_all(b"This is a second test line\n").unwrap();
 //! parz.finish().unwrap();
@@ -107,7 +107,7 @@ where
     }
 
     /// Create a configured [`ParCompress`] object.
-    pub fn from_writer<W: Write + Send + 'static>(self, writer: W) -> ParCompress<F> {
+    pub fn from_writer<W: Write + Send + 'static>(self, writer: W) -> ParCompress<F, W> {
         let (tx_compressor, rx_compressor) = bounded(self.num_threads * 2);
         let (tx_writer, rx_writer) = bounded(self.num_threads * 2);
         let buffer_size = self.buffer_size;
@@ -147,11 +147,12 @@ where
 }
 
 #[allow(unused)]
-pub struct ParCompress<F>
+pub struct ParCompress<F, W>
 where
     F: FormatSpec,
+    W: Write,
 {
-    handle: Option<std::thread::JoinHandle<Result<(), GzpError>>>,
+    handle: Option<std::thread::JoinHandle<Result<W, GzpError>>>,
     tx_compressor: Option<Sender<Message<F::C>>>,
     tx_writer: Option<Sender<Receiver<CompressResult<F::C>>>>,
     buffer: BytesMut,
@@ -160,9 +161,10 @@ where
     format: F,
 }
 
-impl<F> ParCompress<F>
+impl<F, W> ParCompress<F, W>
 where
     F: FormatSpec,
+    W: Write,
 {
     /// Create a builder to configure the [`ParCompress`] runtime.
     pub fn builder() -> ParCompressBuilder<F> {
@@ -172,7 +174,7 @@ where
     /// Launch threads to compress chunks and coordinate sending compressed results
     /// to the writer.
     #[allow(clippy::needless_collect)]
-    fn run<W>(
+    fn run(
         rx: &Receiver<Message<F::C>>,
         rx_writer: &Receiver<Receiver<CompressResult<F::C>>>,
         mut writer: W,
@@ -180,7 +182,7 @@ where
         compression_level: Compression,
         format: F,
         pin_threads: Option<usize>,
-    ) -> Result<(), GzpError>
+    ) -> Result<W, GzpError>
     where
         W: Write + Send + 'static,
     {
@@ -245,7 +247,8 @@ where
             .try_for_each(|handle| match handle.join() {
                 Ok(result) => result,
                 Err(e) => std::panic::resume_unwind(e),
-            })
+            })?;
+        Ok(writer)
     }
 
     /// Flush this output stream, ensuring all intermediately buffered contents are sent.
@@ -288,9 +291,10 @@ where
     }
 }
 
-impl<F> ZWriter for ParCompress<F>
+impl<F, W> ZWriter<W> for ParCompress<F, W>
 where
     F: FormatSpec,
+    W: Write,
 {
     /// Flush the buffers and wait on all threads to finish working.
     ///
@@ -299,9 +303,7 @@ where
     /// # Errors
     /// - [`GzpError`] if there is an issue flushing the last blocks or an issue joining on the writer thread
     ///
-    /// # Panics
-    /// - If called twice
-    fn finish(&mut self) -> Result<(), GzpError> {
+    fn finish(&mut self) -> Result<W, GzpError> {
         self.flush_last(true)?;
 
         // while !self.tx_compressor.as_ref().unwrap().is_empty() {}
@@ -315,9 +317,10 @@ where
     }
 }
 
-impl<F> Drop for ParCompress<F>
+impl<F, W> Drop for ParCompress<F, W>
 where
     F: FormatSpec,
+    W: Write,
 {
     fn drop(&mut self) {
         if self.tx_compressor.is_some() && self.tx_writer.is_some() && self.handle.is_some() {
@@ -327,9 +330,10 @@ where
     }
 }
 
-impl<F> Write for ParCompress<F>
+impl<F, W> Write for ParCompress<F, W>
 where
     F: FormatSpec,
+    W: Write,
 {
     /// Write a buffer into this writer, returning how many bytes were written.
     ///
@@ -354,7 +358,7 @@ where
                     // If an error occured sending, that means the recievers have dropped an the compressor thread hit an error
                     // Collect that error here, and if it was an Io error, preserve it
                     let error = match self.handle.take().unwrap().join() {
-                        Ok(result) => result,
+                        Ok(result) => result.map(|_| ()),
                         Err(e) => std::panic::resume_unwind(e),
                     };
                     match error {
@@ -371,7 +375,7 @@ where
                     // If an error occured sending, that means the recievers have dropped an the compressor thread hit an error
                     // Collect that error here, and if it was an Io error, preserve it
                     let error = match self.handle.take().unwrap().join() {
-                        Ok(result) => result,
+                        Ok(result) => result.map(|_| ()),
                         Err(e) => std::panic::resume_unwind(e),
                     };
                     match error {

--- a/src/par/compress.rs
+++ b/src/par/compress.rs
@@ -138,6 +138,27 @@ where
     }
 
     /// Create a configured [`ParCompress`] object.
+    ///
+    /// This is similar to [`from_writer`](ParCompressBuilder::from_writer) but allows
+    /// the writer to be borrowed for the lifetime of the specified scope, rather than
+    /// requiring it to be `'static`.
+    ///
+    /// ```rust
+    /// use gzp::par::compress::ParCompressBuilder;
+    /// use gzp::deflate::Gzip;
+    /// use gzp::ZWriter;
+    /// use std::io::Write;
+    ///
+    /// let mut output = Vec::new();
+    ///
+    /// std::thread::scope(|scope| {
+    ///     let mut compressor = ParCompressBuilder::<Gzip>::new()
+    ///         .from_borrowed_writer(&mut output, scope);
+    ///     
+    ///     compressor.write_all(b"Data to compress").unwrap();
+    ///     compressor.finish().unwrap()
+    /// });
+    /// ````
     pub fn from_borrowed_writer<'scope, 'env, W: Write + Send + 'scope>(
         self,
         writer: W,


### PR DESCRIPTION
I've been trying to use this crate with https://github.com/containers/ocidir-rs to create container images. Getting that working required two changes to gzp:
* the ability to return the underlying writer from Zwriter::finish
* the ability to use borrowed writers in ParCompressBuilder::from_borrowed_writer

The latter is accomplished by allowing users to provide a `https://doc.rust-lang.org/stable/std/thread/struct.Scope.html` alongside the writer - the writer thread is then spawned using this scope.
