### PR TITLE
fix: a failed teardown returns Err instead of panicking in Drop (#68)

### DIFF
--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -774,6 +774,99 @@ mod test {
         assert_eq!(input.to_vec(), bytes);
     }
 
+    /// A sink where every write fails, standing in for a full disk or a pipe that has
+    /// gone away. It signals on drop, which happens on the writer thread as that thread
+    /// unwinds out of `run`, so a test can wait for the failure rather than sleep on it.
+    #[derive(Debug)]
+    struct FailingSink(std::sync::mpsc::Sender<()>);
+
+    impl Write for FailingSink {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("sink is gone"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Drop for FailingSink {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
+    /// Build a writer over a [`FailingSink`] and return once the writer thread has died
+    /// on the gzip header, which is the first thing it writes.
+    ///
+    /// Nothing here is written by the caller, which removes the race: the only sends in
+    /// the test are the teardown's own.
+    fn dead_writer_thread() -> ParCompress<'static, Gzip, FailingSink> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let par_gz: ParCompress<Gzip, _> = ParCompressBuilder::new()
+            .num_threads(1)
+            .unwrap()
+            .from_writer(FailingSink(tx));
+
+        // The sink is dropped as the writer thread returns, so this wakes up once that
+        // thread is on its way out rather than after a guessed-at duration. The channels
+        // it receives on are closed a few instructions later, when the closure holding
+        // them is dropped; that is what the pause covers. Both tests below still assert
+        // correctly if it is not long enough on some machine -- see their comments.
+        rx.recv_timeout(std::time::Duration::from_secs(60))
+            .expect("the writer thread should have failed on the gzip header");
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        par_gz
+    }
+
+    #[test]
+    fn test_finish_error_does_not_panic_on_drop() {
+        let mut par_gz = dead_writer_thread();
+
+        let err = par_gz
+            .finish()
+            .expect_err("finish() should report the sink's failure");
+
+        // The writer thread was joined on the way out, so the caller gets the error the
+        // sink actually returned rather than the send failure it caused.
+        assert!(
+            matches!(&err, GzpError::Io(ioerr) if ioerr.to_string().contains("sink is gone")),
+            "expected the sink's own error, got {:?}",
+            err
+        );
+
+        // The drop at the end of this scope is the regression: it must not re-enter
+        // finish() and unwrap the same error.
+        //
+        // If the channels have not closed yet, finish()'s sends succeed and it reports
+        // the same error from the join instead -- so this test cannot fail spuriously,
+        // it can only stop covering the send path.
+    }
+
+    #[test]
+    fn test_flush_error_does_not_panic_on_drop() {
+        let mut par_gz = dead_writer_thread();
+
+        // flush() is the other way into flush_last. Retry rather than assume the
+        // channels have closed: the writer thread is already dead, so this terminates.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        let err = loop {
+            match par_gz.flush() {
+                Err(err) => break err,
+                Ok(()) => assert!(
+                    std::time::Instant::now() < deadline,
+                    "flush() never reported the sink's failure"
+                ),
+            }
+        };
+        assert!(
+            err.to_string().contains("sink is gone"),
+            "expected the sink's own error, got {:?}",
+            err
+        );
+
+        // As above: dropping after a failed flush must not panic either.
+    }
+
     #[test]
     fn test_simple_sync() {
         let dir = tempdir().unwrap();

--- a/src/par/compress.rs
+++ b/src/par/compress.rs
@@ -242,6 +242,35 @@ where
         ParCompressBuilder::new()
     }
 
+    /// Join the writer thread and produce the error it exited with.
+    ///
+    /// Call this when a send fails: the send only fails because the receiving end has
+    /// hung up, which means the writer thread is already gone and the real cause is
+    /// whatever it returned. Taking the handle here also disarms [`Drop`], whose guard
+    /// requires all three of `tx_compressor` / `tx_writer` / `handle` to be `Some`, so a
+    /// teardown that has already failed is never silently retried by the drop that
+    /// follows it.
+    fn writer_thread_error(&mut self) -> io::Error {
+        let handle = match self.handle.take() {
+            Some(handle) => handle,
+            // Already joined by an earlier failure on this same object, which reported
+            // the underlying error to whoever hit it first.
+            None => return io::Error::other(GzpError::ChannelSend),
+        };
+        // If an error occurred sending, that means the receivers have dropped and the
+        // compressor thread hit an error. Collect that error here, and if it was an Io
+        // error, preserve it.
+        let error = match handle.join() {
+            Ok(result) => result.map(|_| ()),
+            Err(e) => std::panic::resume_unwind(e),
+        };
+        match error {
+            Ok(()) => std::panic::resume_unwind(Box::new(error)), // something weird happened
+            Err(GzpError::Io(ioerr)) => ioerr,
+            Err(err) => io::Error::other(err),
+        }
+    }
+
     /// Launch threads to compress chunks and coordinate sending compressed results
     /// to the writer.
     #[allow(clippy::needless_collect)]
@@ -348,12 +377,12 @@ where
                 .as_ref()
                 .unwrap()
                 .send(r)
-                .map_err(io::Error::other)?;
+                .map_err(|_send_error| self.writer_thread_error())?;
             self.tx_compressor
                 .as_ref()
                 .unwrap()
                 .send(m)
-                .map_err(io::Error::other)?;
+                .map_err(|_send_error| self.writer_thread_error())?;
             if self.buffer.is_empty() {
                 break;
             }
@@ -374,6 +403,8 @@ where
     /// # Errors
     /// - [`GzpError`] if there is an issue flushing the last blocks or an issue joining on the writer thread
     ///
+    /// A `finish` that returns `Err` has already joined the writer thread and left this
+    /// object inert, so the [`Drop`] that follows will not try the teardown again.
     fn finish(&mut self) -> Result<W, GzpError> {
         self.flush_last(true)?;
 
@@ -381,9 +412,16 @@ where
         // while !self.tx_writer.as_ref().unwrap().is_empty() {}
         drop(self.tx_compressor.take());
         drop(self.tx_writer.take());
-        match self.handle.take().unwrap().join() {
-            Ok(result) => result,
-            Err(e) => std::panic::resume_unwind(e),
+        match self.handle.take() {
+            Some(handle) => match handle.join() {
+                Ok(result) => result,
+                Err(e) => std::panic::resume_unwind(e),
+            },
+            // Not reachable today: the handle is only taken on a path that also closes
+            // the channels `flush_last` sends on, so the `?` above returns first. It is
+            // an error rather than an `unwrap` because that reasoning is what this whole
+            // function got wrong before.
+            None => Err(GzpError::ChannelSend),
         }
     }
 }
@@ -425,36 +463,12 @@ where
                 .as_ref()
                 .unwrap()
                 .send(r)
-                .map_err(|_send_error| {
-                    // If an error occured sending, that means the recievers have dropped an the compressor thread hit an error
-                    // Collect that error here, and if it was an Io error, preserve it
-                    let error = match self.handle.take().unwrap().join() {
-                        Ok(result) => result.map(|_| ()),
-                        Err(e) => std::panic::resume_unwind(e),
-                    };
-                    match error {
-                        Ok(()) => std::panic::resume_unwind(Box::new(error)), // something weird happened
-                        Err(GzpError::Io(ioerr)) => ioerr,
-                        Err(err) => io::Error::other(err),
-                    }
-                })?;
+                .map_err(|_send_error| self.writer_thread_error())?;
             self.tx_compressor
                 .as_ref()
                 .unwrap()
                 .send(m)
-                .map_err(|_send_error| {
-                    // If an error occured sending, that means the recievers have dropped an the compressor thread hit an error
-                    // Collect that error here, and if it was an Io error, preserve it
-                    let error = match self.handle.take().unwrap().join() {
-                        Ok(result) => result.map(|_| ()),
-                        Err(e) => std::panic::resume_unwind(e),
-                    };
-                    match error {
-                        Ok(()) => std::panic::resume_unwind(Box::new(error)), // something weird happened
-                        Err(GzpError::Io(ioerr)) => ioerr,
-                        Err(err) => io::Error::other(err),
-                    }
-                })?;
+                .map_err(|_send_error| self.writer_thread_error())?;
             self.buffer
                 .reserve(self.buffer_size.saturating_sub(self.buffer.len()));
         }


### PR DESCRIPTION
Closes #68.

`ParCompress::finish()` can return `Err` with all three of `tx_compressor`, `tx_writer`
and `handle` still `Some` — which is exactly the condition `Drop` tests before calling
`self.finish().unwrap()`. A caller that does the correct thing and propagates the error
gets a panic on the way out of scope instead of its error.

### The shape of the fix

`Write::write` already handles a failed send correctly: on `SendError` it does
`self.handle.take().unwrap().join()` to recover the writer thread's real error, and taking
the handle disarms `Drop` as a side effect. That block appears twice in `write` and nowhere
else — `flush_last`, the send path that both `finish()` and `Write::flush` go through, just
does `.map_err(io::Error::other)` and returns with the guard armed.

So this lifts that block into one private `writer_thread_error(&mut self)` and calls it
from all four sends. Three consequences, in the order they matter:

1. **The guard is disarmed on every failing send**, so a failed `finish()` *or* `flush()`
   leaves the object inert and the drop that follows does nothing. That is the bug.
2. **`finish()` and `flush()` now return the writer thread's own error** rather than the
   `SendError` it caused. On the reproducer in #68 that is the difference between
   `Io(Custom { kind: Other, error: "SendError(..)" })` and
   `Io(Custom { kind: Other, error: "sink is gone" })`. It is a visible behaviour change,
   on a path that used to panic — so nothing can have depended on the old value — but it
   is a change, and I would rather name it than have you find it.
3. The two copies of that block in `write` become one call.

Two `Option::unwrap`s go with it, because both are reachable once the handle can
legitimately be gone:

  * `writer_thread_error` returns `GzpError::ChannelSend` if the handle was already taken
    by an earlier failure on the same object. `write`'s old code panicked there — a second
    `write` after a failed one hits it.
  * `finish` matches on `self.handle.take()` instead of unwrapping it. **That arm is not
    reachable today**: the only path that takes the handle also closes the channels
    `flush_last` sends on, so the `?` above it returns first. It is an error and not an
    `unwrap` because reasoning of exactly that shape is what the function got wrong in the
    first place.

`Drop` itself is unchanged and still `unwrap()`s. Dropping without calling `finish` is a
supported way to use this type — `test_simple_drop` covers it — and a panic is the only
channel a `Drop` has to say the output is short. `ParDecompress`'s `Drop` takes the same
line.

### Tests

Two, in `src/deflate.rs` beside `test_simple_drop`, one per entry point into `flush_last`.
Both fail on `main` @`54b7dcb` with the panic from #68 and pass here:

```
thread 'deflate::test::test_finish_error_does_not_panic_on_drop' panicked at
  src/par/compress.rs:398:27:
called `Result::unwrap()` on an `Err` value: Io(Custom { kind: Other, error: "SendError(..)" })
```

**They do not sleep on the race.** The sink signals from its own `Drop`, which runs on the
writer thread as that thread unwinds out of `run`, so the test blocks until the writer
thread is actually on its way out. The receivers close a few instructions after that, and
the two tests handle that window differently on purpose: the `flush` test retries (the
thread is already dead, so it terminates), and the `finish` test does not need to, because
if the channels have not closed yet `finish` reports the same error from the join instead.
Neither can fail spuriously — at worst the second one stops covering the send path.

Nothing is written by the caller in either test, which is what removes the race in the
first place: the only sends in the program are the teardown's own.

### What I ran

Everything below is a run on one Linux box — `rustc 1.97.1`, `x86_64-unknown-linux-gnu` —
against `main` @`54b7dcb`, measured on *both* trees by stashing the patch and re-running.

|                                                          | pristine `main`                               | this branch              |
|---|---|---|
| `cargo test --all-features` (lib)                        | 14 passed, 9 ignored                          | **16 passed**, 9 ignored |
| `cargo test --all-features` (doc)                        | 7 passed                                      | 7 passed                 |
| `cargo test --all-features -- --ignored`                 | not run                                       | **9 passed**, 245s       |
| the two new tests                                        | **both fail** — panic at `compress.rs:398:27` | both pass                |
| `cargo clippy --all-features -- -D warnings` (CI's line) | clean                                         | clean                    |
| `cargo fmt --all -- --check`                             | clean                                         | clean                    |

`cargo test --no-default-features --features deflate_rust --lib` — the pure-Rust backend,
with no C dependency anywhere in the tree: **10 -> 12 passed, 0 failed**. Same two tests,
same behaviour.

The two new tests were then run **100 times in a row** on this branch: **0 failures**.

One thing worth naming rather than leaving for you to find: `cargo clippy --all-features
--all-targets -- -D warnings` fails on *both* trees, and none of it is this patch — the
same two `collapsible_if`s in the existing proptest module (moved down by the lines this
adds) plus lints under `examples/`. CI's lints job does not pass `--all-targets`, so it
does not see them.

### What I did not run

The Windows and macOS legs of CI — this is one Linux box, and those are yours to see. It
also has no system C compiler, `make` or `cmake`: `cc` is a `zig cc` shim and
`cmake`/`ninja` came from pip. That is why the `deflate_rust` line is there as well — it is
the one leg with no C dependency at all, so it is the one whose result does not lean on any
of that.

### Context

Found while making a gzip teardown's error reportable in
[TrimGalore#436](https://github.com/FelixKrueger/TrimGalore/pull/436), which is merged. It
carries a local `std::mem::forget` on the error path to work around this; once this lands
that becomes a one-commit revert there, which I will open.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. Every number above is a run on the machine
that wrote it rather than an inference: the two tests were run against pristine `main`
first and are quoted failing, the clippy comparison was made by stashing the patch and
re-running, and the not-run list is what this box could not build rather than what was not
attempted.

</details>
