### PR TITLE
fix: disarm ParCompress after send errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.0.3
+
+- fix: Prevent `ParCompress` from attempting teardown twice after an internal writer error, so `write`, `flush`, and `finish` preserve the original error instead of panicking during `Drop` ([#68](https://github.com/sstadick/gzp/issues/68)).
+- perf: Keep send-error recovery on the cold error path so successful compression does not pay for teardown handling.
+
 # v2.0.2
 
 - fix: https://github.com/sstadick/gzp/issues/65, incorrect feature flags that get exposed when compiling without default features for snappy only.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "gzp"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.40"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -150,9 +150,9 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -265,9 +265,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gzp"
 authors = ["Seth Stadick <sstadick@gmail.com>"]
-version = "2.0.2"
+version = "2.0.3"
 edition = "2018"
 license = "Unlicense/MIT"
 readme = "README.md"

--- a/src/par/compress.rs
+++ b/src/par/compress.rs
@@ -344,21 +344,41 @@ where
                 self.dictionary = Some(m.buffer.slice(m.buffer.len() - DICT_SIZE..));
             }
 
-            self.tx_writer
-                .as_ref()
-                .unwrap()
-                .send(r)
-                .map_err(io::Error::other)?;
-            self.tx_compressor
-                .as_ref()
-                .unwrap()
-                .send(m)
-                .map_err(io::Error::other)?;
+            let send_result = self.tx_writer.as_ref().unwrap().send(r);
+            if let Err(error) = send_result {
+                return Err(self.recover_send_error(error));
+            }
+
+            let send_result = self.tx_compressor.as_ref().unwrap().send(m);
+            if let Err(error) = send_result {
+                return Err(self.recover_send_error(error));
+            }
             if self.buffer.is_empty() {
                 break;
             }
         }
         Ok(())
+    }
+
+    /// Shut down the pipeline and recover its error after a channel send fails.
+    ///
+    /// Taking all three resources before joining also disarms [`Drop`], so an error
+    /// returned by `write`, `flush`, or `finish` cannot trigger a second teardown.
+    fn recover_send_error<T>(&mut self, send_error: flume::SendError<T>) -> io::Error {
+        let handle = self.handle.take().unwrap();
+        drop(send_error);
+        drop(self.tx_compressor.take());
+        drop(self.tx_writer.take());
+
+        let error = match handle.join() {
+            Ok(result) => result.map(|_| ()),
+            Err(error) => std::panic::resume_unwind(error),
+        };
+        match error {
+            Ok(()) => std::panic::resume_unwind(Box::new(error)),
+            Err(GzpError::Io(error)) => error,
+            Err(error) => io::Error::other(error),
+        }
     }
 }
 
@@ -421,40 +441,15 @@ where
             } else {
                 None
             };
-            self.tx_writer
-                .as_ref()
-                .unwrap()
-                .send(r)
-                .map_err(|_send_error| {
-                    // If an error occured sending, that means the recievers have dropped an the compressor thread hit an error
-                    // Collect that error here, and if it was an Io error, preserve it
-                    let error = match self.handle.take().unwrap().join() {
-                        Ok(result) => result.map(|_| ()),
-                        Err(e) => std::panic::resume_unwind(e),
-                    };
-                    match error {
-                        Ok(()) => std::panic::resume_unwind(Box::new(error)), // something weird happened
-                        Err(GzpError::Io(ioerr)) => ioerr,
-                        Err(err) => io::Error::other(err),
-                    }
-                })?;
-            self.tx_compressor
-                .as_ref()
-                .unwrap()
-                .send(m)
-                .map_err(|_send_error| {
-                    // If an error occured sending, that means the recievers have dropped an the compressor thread hit an error
-                    // Collect that error here, and if it was an Io error, preserve it
-                    let error = match self.handle.take().unwrap().join() {
-                        Ok(result) => result.map(|_| ()),
-                        Err(e) => std::panic::resume_unwind(e),
-                    };
-                    match error {
-                        Ok(()) => std::panic::resume_unwind(Box::new(error)), // something weird happened
-                        Err(GzpError::Io(ioerr)) => ioerr,
-                        Err(err) => io::Error::other(err),
-                    }
-                })?;
+            let send_result = self.tx_writer.as_ref().unwrap().send(r);
+            if let Err(error) = send_result {
+                return Err(self.recover_send_error(error));
+            }
+
+            let send_result = self.tx_compressor.as_ref().unwrap().send(m);
+            if let Err(error) = send_result {
+                return Err(self.recover_send_error(error));
+            }
             self.buffer
                 .reserve(self.buffer_size.saturating_sub(self.buffer.len()));
         }
@@ -465,5 +460,201 @@ where
     /// Flush this output stream, ensuring all intermediately buffered contents are sent.
     fn flush(&mut self) -> std::io::Result<()> {
         self.flush_last(false)
+    }
+}
+
+#[cfg(all(test, feature = "deflate"))]
+mod tests {
+    use std::io::{self, Write};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    use crate::deflate::Gzip;
+    use crate::{GzpError, ZWriter};
+
+    use super::{MaybeScopedJoinHandle, ParCompress, ParCompressBuilder};
+
+    #[derive(Debug)]
+    struct FailingWriter {
+        write_attempted: mpsc::Sender<()>,
+    }
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            let _ = self.write_attempted.send(());
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "sink is gone"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct PanickingWriter {
+        write_attempted: mpsc::Sender<()>,
+    }
+
+    impl Write for PanickingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            let _ = self.write_attempted.send(());
+            panic!("sink panicked");
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn wait_for_writer_thread<W: Write>(compressor: &ParCompress<'_, Gzip, W>) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let is_finished = match compressor.handle.as_ref().unwrap() {
+                MaybeScopedJoinHandle::Static(handle) => handle.is_finished(),
+                MaybeScopedJoinHandle::Scoped(handle) => handle.is_finished(),
+            };
+            if is_finished {
+                return;
+            }
+            assert!(Instant::now() < deadline, "writer thread did not finish");
+            std::thread::yield_now();
+        }
+    }
+
+    fn compressor_with_failed_writer() -> ParCompress<'static, Gzip, FailingWriter> {
+        let (write_attempted, write_attempted_rx) = mpsc::channel();
+        let compressor = ParCompressBuilder::new()
+            .num_threads(1)
+            .unwrap()
+            .from_writer(FailingWriter { write_attempted });
+
+        write_attempted_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("writer did not attempt the gzip header");
+        wait_for_writer_thread(&compressor);
+        compressor
+    }
+
+    fn assert_pipeline_closed<W: Write>(compressor: &ParCompress<'_, Gzip, W>) {
+        assert!(compressor.handle.is_none());
+        assert!(compressor.tx_compressor.is_none());
+        assert!(compressor.tx_writer.is_none());
+    }
+
+    fn assert_sink_error(error: GzpError) {
+        match error {
+            GzpError::Io(error) => {
+                assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+                assert_eq!(error.to_string(), "sink is gone");
+            }
+            error => panic!("expected the sink's I/O error, got {:?}", error),
+        }
+    }
+
+    #[test]
+    fn finish_error_is_not_retried_by_drop() {
+        let mut compressor = compressor_with_failed_writer();
+        let result = catch_unwind(AssertUnwindSafe(move || {
+            let result = compressor.finish();
+            assert_pipeline_closed(&compressor);
+            drop(compressor);
+            result
+        }));
+
+        let error = result
+            .expect("dropping after a failed finish must not panic")
+            .expect_err("finish should report the sink error");
+        assert_sink_error(error);
+    }
+
+    #[test]
+    fn flush_error_is_not_retried_by_drop() {
+        let mut compressor = compressor_with_failed_writer();
+        let result = catch_unwind(AssertUnwindSafe(move || {
+            let result = compressor.flush();
+            assert_pipeline_closed(&compressor);
+            drop(compressor);
+            result
+        }));
+
+        let error = result
+            .expect("dropping after a failed flush must not panic")
+            .expect_err("flush should report the sink error");
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+        assert_eq!(error.to_string(), "sink is gone");
+    }
+
+    #[test]
+    fn write_error_still_recovers_the_sink_error() {
+        let mut compressor = compressor_with_failed_writer();
+        let input = vec![0; compressor.buffer_size + 1];
+        let result = catch_unwind(AssertUnwindSafe(move || {
+            let result = compressor.write(&input);
+            assert_pipeline_closed(&compressor);
+            drop(compressor);
+            result
+        }));
+
+        let error = result
+            .expect("dropping after a failed write must not panic")
+            .expect_err("write should report the sink error");
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+        assert_eq!(error.to_string(), "sink is gone");
+    }
+
+    #[test]
+    fn scoped_finish_error_is_not_retried_by_drop() {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            std::thread::scope(|scope| {
+                let (write_attempted, write_attempted_rx) = mpsc::channel();
+                let mut compressor = ParCompressBuilder::new()
+                    .num_threads(1)
+                    .unwrap()
+                    .from_borrowed_writer(FailingWriter { write_attempted }, scope);
+
+                write_attempted_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("writer did not attempt the gzip header");
+                wait_for_writer_thread(&compressor);
+
+                let error = compressor
+                    .finish()
+                    .expect_err("finish should report the sink error");
+                assert_pipeline_closed(&compressor);
+                assert_sink_error(error);
+                drop(compressor);
+            });
+        }));
+
+        result.expect("dropping a failed scoped compressor must not panic");
+    }
+
+    #[test]
+    fn writer_panic_is_resumed_only_once() {
+        let (write_attempted, write_attempted_rx) = mpsc::channel();
+        let mut compressor = ParCompressBuilder::new()
+            .num_threads(1)
+            .unwrap()
+            .from_writer(PanickingWriter { write_attempted });
+        write_attempted_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("writer did not attempt the gzip header");
+        wait_for_writer_thread(&compressor);
+
+        let result = catch_unwind(AssertUnwindSafe(move || {
+            let panic = catch_unwind(AssertUnwindSafe(|| compressor.finish()));
+            assert_pipeline_closed(&compressor);
+            drop(compressor);
+            panic
+        }))
+        .expect("dropping after resuming the writer panic must not panic again");
+
+        let panic = result.expect_err("the writer panic should be resumed");
+        let message = panic
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| panic.downcast_ref::<String>().map(String::as_str));
+        assert_eq!(message, Some("sink panicked"));
     }
 }

--- a/src/par/compress.rs
+++ b/src/par/compress.rs
@@ -364,6 +364,7 @@ where
     ///
     /// Taking all three resources before joining also disarms [`Drop`], so an error
     /// returned by `write`, `flush`, or `finish` cannot trigger a second teardown.
+    #[cold]
     fn recover_send_error<T>(&mut self, send_error: flume::SendError<T>) -> io::Error {
         let handle = self.handle.take().unwrap();
         drop(send_error);


### PR DESCRIPTION
Fixes #68.

## What changed

- Centralize failed channel-send recovery in `ParCompress::recover_send_error`.
- Take the writer handle and both channel senders before returning an error, which:
  - disarms `Drop` before the error escapes;
  - prevents a second teardown attempt and panic;
  - wakes compression workers instead of leaving them parked until the object is dropped.
- Drop the failed send payload before joining the writer thread.
- Preserve the writer thread's original I/O error rather than exposing the secondary channel-send failure.
- Reuse the same recovery path from `write`, `flush`, and `finish`'s shared `flush_last` path.

This is an independently derived alternative to #69. The main behavioral difference is that all three pipeline resources are cleared immediately on failure, not just the join handle.

## Regression coverage

Five deterministic tests cover:

- failed `finish()` followed by `Drop`;
- failed `flush()` followed by `Drop`;
- existing `write()` error recovery;
- scoped writer join handles;
- writer-thread panics being resumed exactly once.

The tests wait for `JoinHandle::is_finished()` rather than sleeping on the race, assert the original error kind/message, and assert that `handle`, `tx_compressor`, and `tx_writer` are all `None` before the error escapes.

## Validation

Exact CI-equivalent checks:

- `cargo check --all-features`
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --all-features`: 19 passed, 9 ignored; 7 doctests passed
- `cargo test --all-features -- --ignored`: 9 passed

Additional coverage:

- usable feature/backend matrix: `deflate_rust`, `deflate_zlib`, `deflate_zlib_ng`, `deflate_rust,libdeflate`, `snappy_default`, default, and all features;
- pure-Rust release-mode suite;
- Rust 1.86, pinned Rust 1.90, and Rust 1.95;
- pure-Rust `x86_64-pc-windows-gnu` cross-target check;
- all-feature tests with both 1 and 64 test threads;
- rustdoc with `-D warnings`;
- 1,000 repeated regression-suite iterations (5,000 test cases).

Consumer-level validation used an isolated `crabz` worktree pointed at this checkout:

- 36 round trips across gzip, bgzf, mgzip, zlib, raw deflate, and snap; random and compressible 4 MiB inputs; 1, 2, and 8 compression threads;
- stdout-mode gzip round trip;
- an unbuffered `/dev/full` harness with delayed EOF reproduces #68 on pristine `main` @ `54b7dcb`: exit 101 with the `Drop` unwrap panic;
- the same harness passed 150 times here across 2, 8, and 32 threads, always returning the original `ENOSPC` and never panicking;
- 3 pure-Rust consumer round trips plus 60 equivalent pure-Rust failure injections.

`cargo clippy --all-features --all-targets -- -D warnings` was also attempted; it remains red on pre-existing warnings in examples, benches, and existing deflate tests. The CI Clippy command above is clean.

GitHub Actions now passes all five jobs, including the normal and ignored suites
on Linux, macOS, and Windows. The Windows runner had migrated to Visual Studio
2026, while the locked `cmake 0.1.54` build tooling only recognized Visual Studio
2022 and earlier. Updating the locked CMake/MSVC discovery dependencies restored
the Windows build without pinning CI to an obsolete runner image.

<details>
<summary>AI-assisted</summary>

The implementation and tests were developed with Codex. A blinded sub-agent derived the initial fix from issue #68 without viewing PR #69; the result was then reviewed, expanded, and validated with the matrix above.

</details>
